### PR TITLE
feat: add AWS credentials loader from env and shared config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,17 +1,32 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
 
-type Config struct {
-	Bucket    string
-	ChunkSize int64
-}
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
 
-func LoadConfig(path string) (*Config, error) {
-	fmt.Printf("Loading config from: %s\n", path)
-	// TODO: read YAML or JSON config
-	return &Config{
-		Bucket:    "my-bucket",
-		ChunkSize: 5 * 1024 * 1024,
-	}, nil
+func LoadAWSCredentials() (*credentials.Credentials, error) {
+	envCreds := credentials.NewEnvCredentials()
+	_, err := envCreds.Get()
+	if err == nil {
+		fmt.Println("✔ AWS credentials from environment variables")
+		return envCreds, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user home dir: %w", err)
+	}
+	credFile := filepath.Join(homeDir, ".aws", "credentials")
+	fileCreds := credentials.NewSharedCredentials(credFile, "default")
+	_, err = fileCreds.Get()
+	if err == nil {
+		fmt.Println("AWS credentials from shared credentials file")
+		return fileCreds, nil
+	}
+
+	return nil, fmt.Errorf("AWS credentials not found (env or file)")
 }


### PR DESCRIPTION
## Summary

Add AWS credentials loader to support local authentication using environment variables or shared credentials file.

---

## Changes

- Implemented `LoadAWSCredentials()` in `internal/config/config.go`
- Supports AWS credential loading from environment variables
- Falls back to `~/.aws/credentials` file if env not found
- Added console output to indicate source of loaded credentials

---

## Related Issue

Closes #

---

## Notes


