### PR TITLE
refactor: add S3 bucket access check using AWS SDK v2

### DIFF
--- a/internal/uploader/bucket_check.go
+++ b/internal/uploader/bucket_check.go
@@ -1,0 +1,31 @@
+package uploader
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// CheckS3BucketAccess checks if a given S3 bucket exists and is accessible.
+func CheckS3BucketAccess(ctx context.Context, cfg aws.Config, bucket string) error {
+	client := s3.NewFromConfig(cfg)
+
+	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: &bucket,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "403") {
+			return fmt.Errorf("⚠️ bucket '%s' exists but access is denied", bucket)
+		}
+		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+			return fmt.Errorf("❌ bucket '%s' does not exist", bucket)
+		}
+		return fmt.Errorf("❌ unexpected error checking bucket: %w", err)
+	}
+
+	fmt.Printf("✅ bucket '%s' is accessible\n", bucket)
+	return nil
+}


### PR DESCRIPTION
## Summary

Add S3 bucket access check using AWS SDK v2 before upload operations.

---

## Changes

- Added `CheckS3BucketAccess()` function in `internal/uploader/bucket_check.go`
- Utilizes `s3.HeadBucket()` to verify bucket existence and access
- Differentiates 403 (AccessDenied) and 404 (NoSuchBucket) cases
- Integrated test flow for local credential-based testing

---

## Related Issue

Closes #18 

---

## Notes

- Local testing works with dummy credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
- No actual upload is performed — this is a pre-check utility
