### PR TITLE
feat: add configure.go for one-time setup of Bucket/Key/Region

### DIFF
--- a/internal/cmd/favus/configure.go
+++ b/internal/cmd/favus/configure.go
@@ -1,0 +1,75 @@
+package favus
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoCOMA/Favus/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func promptRequired(label string) string {
+	for {
+		v := promptInput(label) // resume.go에 이미 있는 헬퍼 재사용 (같은 package favus)
+		v = strings.TrimSpace(v)
+		if v != "" {
+			return v
+		}
+		fmt.Println("값이 비어있습니다. 다시 입력해주세요.")
+	}
+}
+
+func promptWithDefault(label, def string) string {
+	v := promptInput(label + fmt.Sprintf(" (default: %s)", def))
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+var configureCmd = &cobra.Command{
+	Use:   "configure",
+	Short: "Interactively set Bucket/Key/Region and persist them for all commands",
+	Long: `Ask for S3 Bucket, default Key, and Region once and save them to a persistent config file.
+After this, other commands will skip interactive prompts for these fields, unless you override with flags or ENV.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// 1) 묻기 (Bucket/Key는 필수, Region은 기본값 ap-northeast-2)
+		bucket := promptRequired("🔧 Enter S3 bucket name")
+		key := promptRequired("📝 Enter default S3 object key")
+		region := promptWithDefault("🌐 Enter AWS Region", "ap-northeast-2")
+
+		// 2) 파일 경로
+		path := config.DefaultConfigPath()
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create config dir: %w", err)
+		}
+
+		// 3) 내용 작성 (YAML)
+		content := []byte(fmt.Sprintf(
+			"bucket: %s\nkey: %s\nregion: %s\n",
+			bucket, key, region,
+		))
+
+		// 원자 저장
+		tmp := path + ".tmp"
+		if err := os.WriteFile(tmp, content, 0o644); err != nil {
+			return fmt.Errorf("write temp config: %w", err)
+		}
+		if err := os.Rename(tmp, path); err != nil {
+			return fmt.Errorf("install config: %w", err)
+		}
+
+		fmt.Printf("✅ Saved config to %s\n", path)
+		fmt.Println("이제부터 Bucket/Key/Region은 이 파일에서 자동으로 불러와서, 각 명령에서 따로 묻지 않습니다.")
+		fmt.Println("필요 시 플래그(--bucket/--key/--region) 또는 ENV로 언제든지 덮어쓸 수 있어요.")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configureCmd)
+}

--- a/internal/cmd/favus/root.go
+++ b/internal/cmd/favus/root.go
@@ -122,20 +122,14 @@ Use 'favus --help' to see available commands.
 
 		case "resume":
 			// required: Bucket, Key, UploadID (status file path is validated in resume.go)
-			effBucket, effKey, effUploadID := envCfg.Bucket, envCfg.Key, envCfg.UploadID
 			if resumeBucket != "" {
-				effBucket = resumeBucket
+				envCfg.Bucket = resumeBucket
 			}
 			if resumeKey != "" {
-				effKey = resumeKey
+				envCfg.Key = resumeKey
 			}
 			if uploadID != "" {
-				effUploadID = uploadID
-			}
-			if effBucket == "" || effKey == "" || effUploadID == "" {
-				needPrompt = true
-			} else {
-				envCfg.Bucket, envCfg.Key, envCfg.UploadID = effBucket, effKey, effUploadID
+				envCfg.UploadID = uploadID
 			}
 
 		case "ls-orphans":

--- a/internal/cmd/favus/upload.go
+++ b/internal/cmd/favus/upload.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/GoCOMA/Favus/internal/awsutils"
@@ -56,6 +57,32 @@ Handles chunking, retries, resume support, and progress visualization automatica
 			fmt.Print("📝 Enter S3 object key: ")
 			in, _ := reader.ReadString('\n')
 			conf.Key = strings.TrimSpace(in)
+		}
+
+		fmt.Printf("📦 Enter part size in MB (minimum 5) [%d]: ", conf.PartSizeMB)
+		psIn, _ := reader.ReadString('\n')
+		psIn = strings.TrimSpace(psIn)
+		if psIn != "" {
+			if mb, err := strconv.Atoi(psIn); err == nil && mb >= 5 {
+				conf.PartSizeMB = mb
+			} else {
+				conf.PartSizeMB = 5
+			}
+		} else if conf.PartSizeMB < 5 {
+			conf.PartSizeMB = 5
+		}
+
+		fmt.Printf("🔁 Enter max concurrency (minimum 1) [%d]: ", conf.MaxConcurrency)
+		ccIn, _ := reader.ReadString('\n')
+		ccIn = strings.TrimSpace(ccIn)
+		if ccIn != "" {
+			if c, err := strconv.Atoi(ccIn); err == nil && c >= 1 {
+				conf.MaxConcurrency = c
+			} else {
+				conf.MaxConcurrency = 1
+			}
+		} else if conf.MaxConcurrency < 1 {
+			conf.MaxConcurrency = 1
 		}
 
 		// 4) Validate local file


### PR DESCRIPTION
## Summary
> Introduce a new favus configure command that interactively collects Bucket, Key, and Region (defaulting Region to ap-northeast-2) and persists them to a config file. After this one-time setup, other commands should not prompt for these values and instead read them automatically.


## Changes
New command: favus configure
Interactive prompts for Bucket, Key, Region (Region defaults to ap-northeast-2 on empty input).
Writes a minimal YAML to ~/.favus/config.yaml:

```
bucket: <name>
key: <object key>
region: <aws-region>

```
Safe write via temp file + atomic rename; re-running overwrites the file with the new values.
Commands now source S3 basics from config
upload, resume, list-uploads, ls-orphans, kill-orphans, delete read Bucket/Key/Region from ~/.favus/config.yaml when present and skip interactive prompts for those fields.

Usage examples
One-time setup:
`favus configure   # prompts for bucket/key/region and writes ~/.favus/config.yaml
`
<img width="989" height="163" alt="image" src="https://github.com/user-attachments/assets/9483a462-6e45-4e40-9296-9ff908ec3186" />
<img width="228" height="74" alt="image" src="https://github.com/user-attachments/assets/1ba1b369-8cb3-4840-a263-74075f73daae" />

<img width="1003" height="115" alt="image" src="https://github.com/user-attachments/assets/f05d805e-1cbd-40b1-b89c-1c66794c5ef2" />

## Related Issue

<!-- e.g. Closes #12, Fixes #34 -->
Closes #33 

---

## Notes

<!-- Any extra context or discussion points (optional) -->