### PR TITLE
feat: add list-buckets command to list all S3 buckets

### DIFF
--- a/internal/cmd/favus/list-buckets.go
+++ b/internal/cmd/favus/list-buckets.go
@@ -1,0 +1,58 @@
+package favus
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/GoCOMA/Favus/internal/awsutils"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/spf13/cobra"
+)
+
+var listBucketsCmd = &cobra.Command{
+	Use:   "list-buckets",
+	Short: "List all S3 buckets in the account",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// 1) AWS config (LocalStack or real AWS)
+		awsCfg, err := awsutils.LoadAWSConfig(profile)
+		if err != nil {
+			return fmt.Errorf("load aws config: %w", err)
+		}
+
+		// 2) Create S3 client
+		s3Client := s3.NewFromConfig(awsCfg)
+
+		// 3) List buckets
+		result, err := s3Client.ListBuckets(context.TODO(), &s3.ListBucketsInput{}) 
+		if err != nil {
+			return fmt.Errorf("could not list buckets: %w", err)
+		}
+
+		if len(result.Buckets) == 0 {
+			fmt.Println("No buckets found in the account.")
+			return nil
+		}
+
+		fmt.Println("Buckets:")
+		for _, bucket := range result.Buckets {
+			bucketName := ""
+			if bucket.Name != nil {
+				bucketName = *bucket.Name
+			}
+			
+			creationDate := "N/A"
+			if bucket.CreationDate != nil {
+				creationDate = bucket.CreationDate.Format(time.RFC3339)
+			}
+			
+			fmt.Printf("- %s (Created: %s)\n", bucketName, creationDate)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listBucketsCmd)
+}


### PR DESCRIPTION
## Summary

Add `list-buckets` CLI command to list all S3 buckets in the configured AWS account (supports LocalStack and real AWS).

---

## Changes

* Implemented new Cobra command `list-buckets`
* Integrated with `awsutils.LoadAWSConfig` for AWS profile handling
* Used `s3.ListBuckets` API to fetch bucket list
* Displayed bucket name and creation date (`RFC3339` format)
* Added fallback messages when no buckets are found
<img width="720" height="85" alt="image" src="https://github.com/user-attachments/assets/b2569d5e-1817-4897-ab5d-04f481ce6cec" />

---

## Related Issue

Closes #36 

---

## Notes

* Tested with both LocalStack and AWS environments
* Example output:

  ```
  Buckets:
  - test-bucket (Created: 2025-09-17T12:30:00Z)
  - favus-data (Created: 2025-09-10T09:12:00Z)
  ```
