### PR TITLE
refactor(cli): introduce CommandContext for shared CLI resources

### DIFF
--- a/internal/awsutils/s3client.go
+++ b/internal/awsutils/s3client.go
@@ -1,0 +1,28 @@
+package awsutils
+
+import (
+    "github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// NewS3Client returns a configured *s3.Client.
+// - cfg: AWS SDK config
+// - endpoint: optional custom S3 endpoint URL (empty = AWS default)
+// - usePathStyle: enable path-style addressing (for local S3-compatible endpoints)
+func NewS3Client(cfg aws.Config, endpoint string, usePathStyle bool) *s3.Client {
+    opts := []func(*s3.Options){}
+
+    opts = append(opts, func(o *s3.Options) {
+        o.UsePathStyle = usePathStyle
+        if endpoint != "" {
+            o.EndpointResolver = s3.EndpointResolverFunc(func(service string, _ s3.EndpointResolverOptions) (aws.Endpoint, error) {
+                return aws.Endpoint{
+                    URL: endpoint,
+                    SigningRegion: cfg.Region,
+                }, nil
+            })
+        }
+    })
+
+    return s3.NewFromConfig(cfg, opts...)
+}

--- a/internal/cmd/favus/cli/input.go
+++ b/internal/cmd/favus/cli/input.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+    "bufio"
+    "fmt"
+    "io"
+    "os"
+    "strings"
+)
+
+func PromptInput(prompt string) string {
+    return PromptInputWithIO(prompt, os.Stdin, os.Stdout)
+}
+
+func PromptInputWithIO(prompt string, r io.Reader, w io.Writer) string {
+    reader := bufio.NewReader(r)
+    fmt.Fprint(w, prompt)
+    in, _ := reader.ReadString('\n')
+    return strings.TrimSpace(in)
+}
+
+func PromptRequired(label string) string {
+    for {
+        v := PromptInput(label) // 기존과 동일하게 label만 넘김
+        v = strings.TrimSpace(v)
+        if v != "" {
+            return v
+        }
+        fmt.Println("값이 비어있습니다. 다시 입력해주세요.")
+    }
+}
+
+func PromptWithDefault(label, def string) string {
+    v := PromptInput(label + fmt.Sprintf(" (default: %s): ", def))
+    v = strings.TrimSpace(v)
+    if v == "" {
+        return def
+    }
+    return v
+}

--- a/internal/cmd/favus/commandcontext.go
+++ b/internal/cmd/favus/commandcontext.go
@@ -1,0 +1,74 @@
+package favus
+
+import (
+    "context"
+	"fmt"
+    "log"
+    "os"
+
+    "github.com/GoCOMA/Favus/internal/awsutils"
+    "github.com/GoCOMA/Favus/internal/config"
+    "github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type CommandContext struct {
+    Ctx     context.Context
+    Config  *config.Config
+    AwsCfg  aws.Config
+    S3      *s3.Client
+    Profile string
+    Debug   bool
+    Logger  *log.Logger
+}
+
+type ctxKey struct{}
+var commandContextKey = ctxKey{}
+
+// BuildCommandContext loads app config, AWS config and creates an S3 client.
+// - profile: AWS profile (can be empty)
+// - configPath: path to YAML config file (empty = use DefaultConfigPath / env)
+// - debug: debug flag
+func BuildCommandContext(parent context.Context, profile, configPath string, debug bool) (*CommandContext, context.Context, error) {
+    // 1) Load application config (uses DefaultConfigPath() and env overrides if path=="")
+    conf, err := config.LoadConfig(configPath)
+    if err != nil {
+        return nil, parent, fmt.Errorf("load app config: %w", err)
+    }
+    if conf == nil {
+        conf = &config.Config{}
+    }
+
+    // 2) Load AWS SDK config (awsutils helper used elsewhere in project)
+    awsCfg, err := awsutils.LoadAWSConfig(profile)
+    if err != nil {
+        return nil, parent, fmt.Errorf("load aws config: %w", err)
+    }
+
+    // 3) Create S3 client via centralized factory (AWS_ENDPOINT_URL optional)
+    endpoint := os.Getenv("AWS_ENDPOINT_URL")
+    usePathStyle := endpoint != ""
+    s3Client := awsutils.NewS3Client(awsCfg, endpoint, usePathStyle)
+
+    cc := &CommandContext{
+        Ctx:     parent,
+        Config:  conf,
+        AwsCfg:  awsCfg,
+        S3:      s3Client,
+        Profile: profile,
+        Debug:   debug,
+        Logger:  log.Default(),
+    }
+    ctx := context.WithValue(parent, commandContextKey, cc)
+    return cc, ctx, nil
+}
+
+// GetCommandContext retrieves the CommandContext from ctx (may return nil).
+func GetCommandContext(ctx context.Context) *CommandContext {
+    if v := ctx.Value(commandContextKey); v != nil {
+        if cc, ok := v.(*CommandContext); ok {
+            return cc
+        }
+    }
+    return nil
+}

--- a/internal/cmd/favus/configure.go
+++ b/internal/cmd/favus/configure.go
@@ -4,31 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
+	"github.com/GoCOMA/Favus/internal/cmd/favus/cli"
 	"github.com/GoCOMA/Favus/internal/config"
 	"github.com/spf13/cobra"
 )
-
-func promptRequired(label string) string {
-	for {
-		v := promptInput(label) // resume.go에 이미 있는 헬퍼 재사용 (같은 package favus)
-		v = strings.TrimSpace(v)
-		if v != "" {
-			return v
-		}
-		fmt.Println("값이 비어있습니다. 다시 입력해주세요.")
-	}
-}
-
-func promptWithDefault(label, def string) string {
-	v := promptInput(label + fmt.Sprintf(" (default: %s)", def))
-	v = strings.TrimSpace(v)
-	if v == "" {
-		return def
-	}
-	return v
-}
 
 var configureCmd = &cobra.Command{
 	Use:   "configure",
@@ -37,9 +17,9 @@ var configureCmd = &cobra.Command{
 After this, other commands will skip interactive prompts for these fields, unless you override with flags or ENV.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// 1) 묻기 (Bucket/Key는 필수, Region은 기본값 ap-northeast-2)
-		bucket := promptRequired("🔧 Enter S3 bucket name")
-		key := promptRequired("📝 Enter default S3 object key")
-		region := promptWithDefault("🌐 Enter AWS Region", "ap-northeast-2")
+		bucket := cli.PromptRequired("🔧 Enter S3 bucket name")
+		key := cli.PromptRequired("📝 Enter default S3 object key")
+		region := cli.PromptWithDefault("🌐 Enter AWS Region", "ap-northeast-2")
 
 		// 2) 파일 경로
 		path := config.DefaultConfigPath()

--- a/internal/cmd/favus/delete.go
+++ b/internal/cmd/favus/delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoCOMA/Favus/internal/cmd/favus/cli"
 	"github.com/GoCOMA/Favus/internal/awsutils"
 	"github.com/GoCOMA/Favus/internal/uploader"
 	"github.com/spf13/cobra"
@@ -44,10 +45,10 @@ var deleteCmd = &cobra.Command{
 
 		// 4) Prompt missing fields
 		if strings.TrimSpace(conf.Bucket) == "" {
-			conf.Bucket = promptInput("🔧 Enter S3 bucket name")
+			conf.Bucket = cli.PromptInput("🔧 Enter S3 bucket name")
 		}
 		if strings.TrimSpace(conf.Key) == "" {
-			conf.Key = promptInput("🗑️  Enter S3 object key to delete")
+			conf.Key = cli.PromptInput("🗑️  Enter S3 object key to delete")
 		}
 
 		// 5) Execute deletion

--- a/internal/cmd/favus/kill-orphans.go
+++ b/internal/cmd/favus/kill-orphans.go
@@ -42,17 +42,15 @@ This is destructive and may interrupt ongoing uploads.`,
 		}
 
 		// 3) S3 client
-		cli := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-			if os.Getenv("AWS_ENDPOINT_URL") != "" {
-				o.UsePathStyle = true
-			}
-		})
+		endpoint := os.Getenv("AWS_ENDPOINT_URL")
+        usePathStyle := endpoint != ""
+        client := awsutils.NewS3Client(awsCfg, endpoint, usePathStyle)
 
 		fmt.Printf("🔍 Scanning bucket '%s' for incomplete multipart uploads...\n", conf.Bucket)
 
 		// 4) 페이지네이션으로 전체 Abort
 		ctx := context.Background()
-		p := s3.NewListMultipartUploadsPaginator(cli, &s3.ListMultipartUploadsInput{
+		p := s3.NewListMultipartUploadsPaginator(client, &s3.ListMultipartUploadsInput{
 			Bucket:     aws.String(conf.Bucket),
 			MaxUploads: aws.Int32(1000),
 		})
@@ -68,7 +66,7 @@ This is destructive and may interrupt ongoing uploads.`,
 				key := aws.ToString(up.Key)
 				uid := aws.ToString(up.UploadId)
 
-				_, err := cli.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+				_, err := client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
 					Bucket:   aws.String(conf.Bucket),
 					Key:      up.Key,
 					UploadId: up.UploadId,

--- a/internal/cmd/favus/kill-orphans.go
+++ b/internal/cmd/favus/kill-orphans.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/GoCOMA/Favus/internal/cmd/favus/cli"
 	"github.com/GoCOMA/Favus/internal/awsutils"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -31,7 +32,7 @@ This is destructive and may interrupt ongoing uploads.`,
 			conf.Bucket = strings.TrimSpace(killBucket)
 		}
 		if strings.TrimSpace(conf.Bucket) == "" {
-			conf.Bucket = promptInput("🔧 Enter S3 bucket name")
+			conf.Bucket = cli.PromptInput("🔧 Enter S3 bucket name")
 		}
 
 		// 2) AWS config

--- a/internal/cmd/favus/list-buckets.go
+++ b/internal/cmd/favus/list-buckets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"os"
 
 	"github.com/GoCOMA/Favus/internal/awsutils"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -21,7 +22,9 @@ var listBucketsCmd = &cobra.Command{
 		}
 
 		// 2) Create S3 client
-		s3Client := s3.NewFromConfig(awsCfg)
+		endpoint := os.Getenv("AWS_ENDPOINT_URL")
+		usePathStyle := endpoint != "" 
+		s3Client := awsutils.NewS3Client(awsCfg, endpoint, usePathStyle)
 
 		// 3) List buckets
 		result, err := s3Client.ListBuckets(context.TODO(), &s3.ListBucketsInput{}) 

--- a/internal/cmd/favus/ls-orphans.go
+++ b/internal/cmd/favus/ls-orphans.go
@@ -47,11 +47,8 @@ that may be wasting storage space and prints their metadata.`,
 
 		// 3. S3 Client 생성 및 로직 실행
 		endpoint := os.Getenv("AWS_ENDPOINT_URL")
-		s3Client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-			if endpoint != "" {
-				o.UsePathStyle = true
-			}
-		})
+		usePathStyle := endpoint != ""
+		s3Client := awsutils.NewS3Client(awsCfg, endpoint, usePathStyle)
 
 		// 4) 페이지네이션으로 진행 중 멀티파트 업로드 나열
 		fmt.Println("🔍 Scanning for incomplete uploads in:", targetBucket)

--- a/internal/cmd/favus/resume.go
+++ b/internal/cmd/favus/resume.go
@@ -1,11 +1,11 @@
 package favus
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/GoCOMA/Favus/internal/cmd/favus/cli"
 	"github.com/GoCOMA/Favus/internal/awsutils"
 	"github.com/GoCOMA/Favus/internal/uploader"
 	"github.com/spf13/cobra"
@@ -18,13 +18,6 @@ var (
 	resumeKey      string
 	uploadID       string
 )
-
-func promptInput(prompt string) string {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Printf("%s: ", prompt)
-	in, _ := reader.ReadString('\n')
-	return strings.TrimSpace(in)
-}
 
 var resumeCmd = &cobra.Command{
 	Use:   "resume",
@@ -60,14 +53,14 @@ If some fields are missing, they are taken from config/ENV, then prompted as nee
 
 		// 4) Prompt for required fields if missing
 		if strings.TrimSpace(conf.Bucket) == "" {
-			conf.Bucket = promptInput("🔧 Enter S3 bucket name")
+			conf.Bucket = cli.PromptInput("🔧 Enter S3 bucket name")
 		}
 		if strings.TrimSpace(conf.Key) == "" {
-			conf.Key = promptInput("📝 Enter S3 object key")
+			conf.Key = cli.PromptInput("📝 Enter S3 object key")
 		}
 		// UploadID may come from status file; if still empty we ask
 		if strings.TrimSpace(conf.UploadID) == "" {
-			conf.UploadID = promptInput("🔁 Enter Upload ID")
+			conf.UploadID = cli.PromptInput("🔁 Enter Upload ID")
 		}
 
 		// 5) Validate status file presence


### PR DESCRIPTION
## Summary

<!-- One-line summary of what this PR does -->
e.g. Add login API and refactor user service

---

## Changes

<!-- List main changes made in this PR -->
- Add CommandContext type and BuildCommandContext/GetCommandContext helpers
- Initialize CommandContext in root PersistentPreRunE and attach to cmd.Context
- Centralize app config and AWS/S3 client creation (uses awsutils.NewS3Client)
- Populate loadedConfig for backward compatibility with existing callers
- No functional behavior change; prepares for cleaner RunE handlers and dependency injection

---

## Related Issue

<!-- e.g. Closes #12, Fixes #34 -->
Closes #

---

## Notes

<!-- Any extra context or discussion points (optional) -->