### PR TITLE
refactor: add chunk cleanup and improve resume functionality

### DIFF
--- a/internal/uploader/resume.go
+++ b/internal/uploader/resume.go
@@ -262,6 +262,14 @@ func (ru *ResumeUploader) ResumeUpload(statusFilePath string) error {
 		utils.Error(fmt.Sprintf("Failed to remove status file %s: %v", statusFilePath, err))
 	}
 
+	// Clean up chunk files
+	utils.Info(fmt.Sprintf("Starting chunk cleanup for %s", status.FilePath))
+	if err := fileChunker.CleanupChunks(); err != nil {
+		utils.Error(fmt.Sprintf("Failed to cleanup chunks for %s: %v", status.FilePath, err))
+	} else {
+		utils.Info(fmt.Sprintf("Successfully cleaned up chunks for %s", status.FilePath))
+	}
+
 	return nil
 }
 

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -155,6 +155,7 @@ func (u *Uploader) UploadFile(filePath, s3Key string) error {
 
 	// Prepare status tracker
 	statusFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%s.upload_status", filepath.Base(filePath), uploadID[:8]))
+	utils.Info(fmt.Sprintf("Status file will be saved to: %s", statusFilePath))
 	status := NewWSTracker(
 		NewUploadStatus(filePath, u.Config.Bucket, s3Key, uploadID, len(chunks), u.Config.PartSizeBytes()),
 	)
@@ -288,6 +289,11 @@ func (u *Uploader) UploadFile(filePath, s3Key string) error {
 	// Clean up status file
 	if err := os.Remove(statusFilePath); err != nil {
 		utils.Error(fmt.Sprintf("Failed to remove status file %s: %v", statusFilePath, err))
+	}
+
+	// Clean up chunk files
+	if err := fileChunker.CleanupChunks(); err != nil {
+		utils.Error(fmt.Sprintf("Failed to cleanup chunks for %s: %v", filePath, err))
 	}
 
 	return nil

--- a/internal/uploader/uploader.go
+++ b/internal/uploader/uploader.go
@@ -154,7 +154,10 @@ func (u *Uploader) UploadFile(filePath, s3Key string) error {
 	r.start(u.Config.Bucket, s3Key, uploadID, u.Config.PartSizeBytes(), nil)
 
 	// Prepare status tracker
-	statusFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%s.upload_status", filepath.Base(filePath), uploadID[:8]))
+	home, _ := os.UserHomeDir()
+	statusDir := filepath.Join(home, ".favus", "status")
+	os.MkdirAll(statusDir, 0755)
+	statusFilePath := filepath.Join(statusDir, fmt.Sprintf("%s_%s.upload_status", filepath.Base(filePath), uploadID[:8]))
 	utils.Info(fmt.Sprintf("Status file will be saved to: %s", statusFilePath))
 	status := NewWSTracker(
 		NewUploadStatus(filePath, u.Config.Bucket, s3Key, uploadID, len(chunks), u.Config.PartSizeBytes()),


### PR DESCRIPTION
## Summary

  - Add automatic chunk file cleanup after successful uploads
  - Fix status file location to be consistent across platforms
  - Improve resume command to auto-read configuration from status files

---

## Changes

 - **uploader.go**: Add chunk cleanup after upload completion + fix status file location to ~/.favus/status/
  - **resume.go**: Add chunk cleanup after resume completion + auto-read bucket/key from status file
  - **resume.go**: Remove unnecessary interactive prompts when data is available in status file

---

## Related Issue

<!-- e.g. Closes #12, Fixes #34 -->
Closes #47 

---

## Notes
<img width="873" height="167" alt="image" src="https://github.com/user-attachments/assets/a32a1c4e-d4e3-4e28-9573-1b1c163c674f" />

<!-- Any extra context or discussion points (optional) -->