### PR TITLE
fix: allow interactive AWS credential prompt when config files are missing

### DIFF
--- a/internal/awsutils/credentials.go
+++ b/internal/awsutils/credentials.go
@@ -27,7 +27,7 @@ func LoadAWSConfig(profile string) (aws.Config, error) {
 	// 1차 시도: 기존 config/cached env
 	cfg, err = config.LoadDefaultConfig(context.TODO(), opts...)
 	if err != nil {
-		// AWS 설정 파일 문법 오류 등 실제 오류는 반환하ㅏ게 했습니다
+		// AWS 설정 파일 문법 오류 등 실제 오류는 반환
 		if isConfigSyntaxError(err) {
 			return cfg, fmt.Errorf(" AWS 설정 파일 오류: %w", err)
 		}


### PR DESCRIPTION
## Summary

  Fix interactive AWS credential prompt not working when config files are missing

  ---

  ## Changes

  - Added `isConfigSyntaxError()` to distinguish config errors from missing files
  - Modified `LoadAWSConfig()` to continue to interactive prompt when AWS config is missing
  - Only block execution on actual configuration syntax errors


## Related Issue

<!-- e.g. Closes #12, Fixes #34 -->
Closes #

---

## Notes

<!-- Any extra context or discussion points (optional) -->