### PR TITLE
feat: keep UI progress alive after websocket timeouts

### DIFF
--- a/internal/uploader/ws_tracker.go
+++ b/internal/uploader/ws_tracker.go
@@ -3,6 +3,8 @@ package uploader
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/GoCOMA/Favus/internal/wsagent"
@@ -12,20 +14,26 @@ import (
 // to updating the local status file.
 type WSTracker struct {
 	*UploadStatus
-	wsEnabled bool
-	wsAddr    string
-	runID     string
+	wsEnabled     bool
+	wsAddr        string
+	runID         string
+	lastCheck     time.Time
+	checkInterval time.Duration
+	lastErrorLog  time.Time
 }
 
 // NewWSTracker creates a new WSTracker wrapper.
 // It auto-detects if the local wsagent is running.
 func NewWSTracker(us *UploadStatus) *WSTracker {
 	addr := wsagent.DefaultAddr()
+	enabled := wsagent.IsRunningAt(addr)
 	return &WSTracker{
-		UploadStatus: us,
-		wsEnabled:    wsagent.IsRunningAt(addr),
-		wsAddr:       addr,
-		runID:        us.UploadID,
+		UploadStatus:  us,
+		wsEnabled:     enabled,
+		wsAddr:        addr,
+		runID:         us.UploadID,
+		checkInterval: 2 * time.Second,
+		lastCheck:     time.Now().Add(-2 * time.Second),
 	}
 }
 
@@ -33,18 +41,19 @@ func NewWSTracker(us *UploadStatus) *WSTracker {
 func (wt *WSTracker) AddCompletedPart(partNumber int, eTag string) {
 	wt.UploadStatus.AddCompletedPart(partNumber, eTag)
 
-	if wt.wsEnabled {
+	if wt.ensureAgent() {
 		payload := map[string]any{
 			"key":  wt.UploadStatus.Key,
 			"part": partNumber,
 			"etag": eTag,
 		}
-		_ = wsagent.SendEvent(context.Background(), wt.wsAddr, wsagent.Event{
+		err := wsagent.SendEvent(context.Background(), wt.wsAddr, wsagent.Event{
 			Type:      "tracker_part_done",
 			RunID:     wt.runID,
 			Timestamp: time.Now(),
 			Payload:   mustJSON(payload),
 		})
+		wt.handleSendError(err, "tracker_part_done")
 	}
 }
 
@@ -55,21 +64,49 @@ func (wt *WSTracker) SaveStatus(statusFilePath string) error {
 		return err
 	}
 
-	if wt.wsEnabled {
+	if wt.ensureAgent() {
 		payload := map[string]any{
 			"key":        wt.UploadStatus.Key,
 			"statusFile": statusFilePath,
 			"partsDone":  len(wt.UploadStatus.CompletedParts),
 			"totalParts": wt.UploadStatus.TotalParts,
 		}
-		_ = wsagent.SendEvent(context.Background(), wt.wsAddr, wsagent.Event{
+		err = wsagent.SendEvent(context.Background(), wt.wsAddr, wsagent.Event{
 			Type:      "tracker_save",
 			RunID:     wt.runID,
 			Timestamp: time.Now(),
 			Payload:   mustJSON(payload),
 		})
+		wt.handleSendError(err, "tracker_save")
 	}
 	return nil
+}
+
+func (wt *WSTracker) ensureAgent() bool {
+	if wt.wsEnabled {
+		return true
+	}
+	if time.Since(wt.lastCheck) < wt.checkInterval {
+		return false
+	}
+	wt.lastCheck = time.Now()
+	if wsagent.IsRunningAt(wt.wsAddr) {
+		wt.wsEnabled = true
+		return true
+	}
+	return false
+}
+
+func (wt *WSTracker) handleSendError(err error, context string) {
+	if err == nil {
+		return
+	}
+	wt.wsEnabled = false
+	wt.lastCheck = time.Now()
+	if time.Since(wt.lastErrorLog) >= 5*time.Second {
+		fmt.Fprintf(os.Stderr, "warn: UI tracker event (%s) delivery failed: %v\n", context, err)
+		wt.lastErrorLog = time.Now()
+	}
 }
 
 // helper: panic 없는 RawMessage 변환


### PR DESCRIPTION
# Summary

<!-- One-line summary of what this PR does -->
feat: keep UI progress alive after websocket timeouts

---

# Changes

<!-- List main changes made in this PR -->
- reconnect upload WebSocket reporting after temporary agent failures
- add retry-friendly session_start handling in CLI progress reporter
- enforce write deadlines in wsagent to avoid stalled connections

---

# Related Issue

<!-- e.g. Closes #12, Fixes #34 -->
Closes #

---

# Notes

<!-- Any extra context or discussion points (optional) -->
Run `./favus ui --endpoint ws://127.0.0.1:8765/ws --foreground` once after deploying to ensure the updated agent binary is active before testing uploads.
